### PR TITLE
feat: Add multi-page navigation, ad placeholder, and new sections

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,74 @@
-import 'package:calcula_fuel/Home.dart';
+import 'package:calcula_fuel/screens/calculator_screen.dart';
+import 'package:calcula_fuel/screens/gas_stations_screen.dart';
+import 'package:calcula_fuel/screens/marketing_screen.dart';
 import 'package:flutter/material.dart';
 
-void main (){
-  
-  runApp(MaterialApp(
-    home:Home() ,
-    debugShowCheckedModeBanner: false, // Remove a fita "DEBUG"
-  ));
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Calculadora de Combustível',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: MainScreen(),
+      debugShowCheckedModeBanner: false, // Remove a fita "DEBUG"
+    );
+  }
+}
+
+class MainScreen extends StatefulWidget {
+  @override
+  _MainScreenState createState() => _MainScreenState();
+}
+
+class _MainScreenState extends State<MainScreen> {
+  int _selectedIndex = 0;
+  static List<Widget> _widgetOptions = <Widget>[
+    CalculatorScreen(),
+    GasStationsScreen(),
+    MarketingScreen(), // Add other screens here
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: _widgetOptions.elementAt(_selectedIndex),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calculate),
+            label: 'Calculator',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.local_gas_station),
+            label: 'Gas Stations',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.campaign),
+            label: 'Marketing',
+          ),
+          // Add other navigation items here
+        ],
+        currentIndex: _selectedIndex,
+        selectedItemColor: Colors.blue,
+        unselectedItemColor: Colors.grey,
+        onTap: _onItemTapped,
+      ),
+    );
+  }
 }
 
 

--- a/lib/screens/calculator_screen.dart
+++ b/lib/screens/calculator_screen.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-class Home extends StatefulWidget {
-  const Home({super.key});
+class CalculatorScreen extends StatefulWidget {
+  const CalculatorScreen({super.key});
 
   @override
-  State<Home> createState() => _HomeState();
+  State<CalculatorScreen> createState() => _CalculatorScreenState();
 }
 
-class _HomeState extends State<Home> {
+class _CalculatorScreenState extends State<CalculatorScreen> {
   final TextEditingController _controllerAlcool = TextEditingController();
   final TextEditingController _controllerGasolina = TextEditingController();
 
@@ -43,12 +43,15 @@ class _HomeState extends State<Home> {
         title: Text("Álcool ou Gasolina"),
         backgroundColor: Colors.lightBlueAccent,
       ),
-      body: Container(
-        padding: EdgeInsets.all(32),
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
+      body: Column(
+        children: <Widget>[
+          Expanded(
+            child: SingleChildScrollView(
+              child: Container(
+                padding: EdgeInsets.all(32),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
               Padding(padding: EdgeInsets.only(bottom: 32)),
               Center(
@@ -118,8 +121,19 @@ class _HomeState extends State<Home> {
                 ),
               ),
             ],
+                  ),
+                ),
+              ),
+            ),
           ),
-        ),
+          Container(
+            height: 50.0,
+            color: Colors.grey[300],
+            child: Center(
+              child: Text("Ad Placeholder"),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/gas_stations_screen.dart
+++ b/lib/screens/gas_stations_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class GasStationsScreen extends StatefulWidget {
+  const GasStationsScreen({super.key});
+
+  @override
+  State<GasStationsScreen> createState() => _GasStationsScreenState();
+}
+
+class _GasStationsScreenState extends State<GasStationsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Gas Stations'),
+        backgroundColor: Colors.lightBlueAccent,
+      ),
+      body: const Center(
+        child: Text('Gas Stations Page - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/screens/marketing_screen.dart
+++ b/lib/screens/marketing_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class MarketingScreen extends StatefulWidget {
+  const MarketingScreen({super.key});
+
+  @override
+  State<MarketingScreen> createState() => _MarketingScreenState();
+}
+
+class _MarketingScreenState extends State<MarketingScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Marketing'),
+        backgroundColor: Colors.lightBlueAccent,
+      ),
+      body: const Center(
+        child: Text('Marketing Page - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   logging: ^1.0.2
   cupertino_icons: ^1.0.8
+  google_mobile_ads: ^5.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This commit introduces several enhancements to the application:

- **Multi-Page Navigation:** The UI has been refactored from a single screen to a multi-page structure using a BottomNavigationBar. This allows for easier expansion with new features.
    - The original calculator functionality is now in `CalculatorScreen`.
    - A `MainScreen` now manages the navigation.

- **Ad Placeholder:** A placeholder container has been added to the `CalculatorScreen` to designate space for future ad integration.

- **Gas Stations Page:** A new, placeholder "Gas Stations" page (`GasStationsScreen`) has been created and added as a tab in the navigation bar. This page is intended for future development of gas station listing features.

- **Marketing Page:** A new, placeholder "Marketing" page (`MarketingScreen`) has been created and added as a tab in the navigation bar. This page is intended for future marketing-related content.

- **Styling:** Basic styling has been applied to the `BottomNavigationBar` for improved visual feedback (selected/unselected item colors).

- **Ad Dependency:** The `google_mobile_ads` dependency has been added to `pubspec.yaml` to prepare for future ad implementation.