### PR TITLE
feat: Implement basic Gas Station input and Marketing display

### DIFF
--- a/assets/promo_placeholder.png
+++ b/assets/promo_placeholder.png
@@ -1,0 +1,1 @@
+This is a placeholder image.

--- a/lib/screens/gas_stations_screen.dart
+++ b/lib/screens/gas_stations_screen.dart
@@ -1,5 +1,20 @@
 import 'package:flutter/material.dart';
 
+// 1. Define a Data Model
+class GasStation {
+  String name;
+  String address;
+  double alcoholPrice;
+  double gasolinePrice;
+
+  GasStation({
+    required this.name,
+    required this.address,
+    required this.alcoholPrice,
+    required this.gasolinePrice,
+  });
+}
+
 class GasStationsScreen extends StatefulWidget {
   const GasStationsScreen({super.key});
 
@@ -8,6 +23,56 @@ class GasStationsScreen extends StatefulWidget {
 }
 
 class _GasStationsScreenState extends State<GasStationsScreen> {
+  // 2. Update GasStationsScreen State
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _addressController = TextEditingController();
+  final TextEditingController _alcoholPriceController = TextEditingController();
+  final TextEditingController _gasolinePriceController = TextEditingController();
+
+  List<GasStation> _savedStations = [];
+
+  void _saveStation() {
+    // Retrieve text from controllers
+    final String name = _nameController.text;
+    final String address = _addressController.text;
+    final double? alcoholPrice = double.tryParse(_alcoholPriceController.text);
+    final double? gasolinePrice = double.tryParse(_gasolinePriceController.text);
+
+    // Perform basic validation
+    if (name.isEmpty || address.isEmpty || alcoholPrice == null || gasolinePrice == null || alcoholPrice <= 0 || gasolinePrice <= 0) {
+      // Show an error message (e.g., using a SnackBar)
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Invalid input. Please check all fields.')),
+      );
+      return;
+    }
+
+    // Create a GasStation object
+    final newStation = GasStation(
+      name: name,
+      address: address,
+      alcoholPrice: alcoholPrice,
+      gasolinePrice: gasolinePrice,
+    );
+
+    // Add the new GasStation object to the _savedStations list
+    setState(() {
+      _savedStations.add(newStation);
+    });
+
+    // Clear the text controllers
+    _nameController.clear();
+    _addressController.clear();
+    _alcoholPriceController.clear();
+    _gasolinePriceController.clear();
+
+    // Print the details of the saved station
+    print('Saved: ${newStation.name}, ${newStation.address}, Alcohol: ${newStation.alcoholPrice}, Gasoline: ${newStation.gasolinePrice}');
+    ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${newStation.name} saved successfully!')),
+      );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -15,8 +80,66 @@ class _GasStationsScreenState extends State<GasStationsScreen> {
         title: const Text('Gas Stations'),
         backgroundColor: Colors.lightBlueAccent,
       ),
-      body: const Center(
-        child: Text('Gas Stations Page - Coming Soon!'),
+      // 3. Build the Input Form
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              TextField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Gas Station Name'),
+                keyboardType: TextInputType.text,
+              ),
+              const SizedBox(height: 10),
+              TextField(
+                controller: _addressController,
+                decoration: const InputDecoration(labelText: 'Address'),
+                keyboardType: TextInputType.text,
+              ),
+              const SizedBox(height: 10),
+              TextField(
+                controller: _alcoholPriceController,
+                decoration: const InputDecoration(labelText: 'Price of Alcohol (e.g., 3.45)'),
+                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              ),
+              const SizedBox(height: 10),
+              TextField(
+                controller: _gasolinePriceController,
+                decoration: const InputDecoration(labelText: 'Price of Gasoline (e.g., 4.99)'),
+                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _saveStation,
+                child: const Text('Save Station'),
+              ),
+              const Divider(height: 30, thickness: 1),
+              // 4. Display Saved Stations
+              Text(
+                'Saved Stations:',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 10),
+              _savedStations.isEmpty
+                  ? const Center(child: Text('No stations saved yet.'))
+                  : ListView.builder(
+                      shrinkWrap: true, // Important to make ListView work inside SingleChildScrollView
+                      physics: const NeverScrollableScrollPhysics(), // Disable scrolling for inner ListView
+                      itemCount: _savedStations.length,
+                      itemBuilder: (context, index) {
+                        final station = _savedStations[index];
+                        return ListTile(
+                          title: Text(station.name),
+                          subtitle: Text('${station.address}\nAlcohol: R\$${station.alcoholPrice.toStringAsFixed(2)} - Gasoline: R\$${station.gasolinePrice.toStringAsFixed(2)}'),
+                          isThreeLine: true,
+                        );
+                      },
+                    ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/marketing_screen.dart
+++ b/lib/screens/marketing_screen.dart
@@ -15,8 +15,66 @@ class _MarketingScreenState extends State<MarketingScreen> {
         title: const Text('Marketing'),
         backgroundColor: Colors.lightBlueAccent,
       ),
-      body: const Center(
-        child: Text('Marketing Page - Coming Soon!'),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // 2. Add Promotional Image Section
+              // Note: 'assets/promo_placeholder.png' is a placeholder path.
+              // The actual asset should be added to pubspec.yaml and the assets folder.
+              Image.asset(
+                'assets/promo_placeholder.png', // Placeholder path
+                height: 200,
+                fit: BoxFit.cover,
+                // ErrorBuilder to show a fallback if the image doesn't load
+                errorBuilder: (context, error, stackTrace) {
+                  return Container(
+                    height: 200,
+                    color: Colors.grey[300],
+                    child: const Center(
+                      child: Text('Image not available'),
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // 3. Add Promotional Text Section
+              Text(
+                'Special Promotion!',
+                style: Theme.of(context).textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 10),
+              Text(
+                "Don't miss out on our exclusive offers! Get the best deals on fuel and services. Visit our partner stations today and save big. This offer is valid for a limited time only.",
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.justify,
+              ),
+              const SizedBox(height: 30),
+
+              // 4. Add Call-to-Action Button
+              ElevatedButton(
+                onPressed: () {
+                  print('Learn More button tapped!');
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Navigating to website... (simulated)')),
+                  );
+                },
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 15), backgroundColor: Colors.amber,
+                ),
+                child: const Text(
+                  'Learn More',
+                  style: TextStyle(fontSize: 16, color: Colors.black),
+                ),
+              ),
+              const SizedBox(height: 20), // Extra spacing at the bottom
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,3 +26,4 @@ flutter:
   assets:
     - assets/logo.png
     - assets/carfuel.png
+    - assets/promo_placeholder.png # New asset


### PR DESCRIPTION
This commit introduces initial features for the Gas Stations and Marketing sections:

- **Gas Stations Page:**
    - You can now input data for gas stations (name, address, alcohol price, gasoline price) via text fields on the `GasStationsScreen`.
    - A "Save Station" button adds the entered data to an in-memory list.
    - The list of saved stations is displayed below the input form.
    - Includes a `GasStation` data model.
    - Basic input validation and feedback via SnackBar are included.

- **Marketing Page:**
    - The `MarketingScreen` now displays a basic layout for promotional content.
    - Includes a placeholder for a promotional image (`Image.asset`).
    - Displays hardcoded promotional title and text.
    - A "Learn More" button simulates a call to action (prints to console and shows SnackBar).

- **Assets:**
    - Added a placeholder image `assets/promo_placeholder.png`.
    - `pubspec.yaml` updated to include the new asset.

These features provide the foundational structure for further development of the gas station and marketing functionalities. Data persistence for gas stations and dynamic content for marketing are potential next steps.